### PR TITLE
Support for source maps in node-sass filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Parses SASS/SCSS into CSS using the LibSass bindings for node.js ([sass/node-sas
 - `output_style`
 - `precision`
 - `source_comments`
+- `source_map_location`
+- `source_map_public_dir`
 
 See [sass/node-sass](https://github.com/sass/node-sass#options) for options description.
 
@@ -142,6 +144,19 @@ Then in your template (Twig example):
 {% stylesheets '../app/Resources/scss/style.scss' filter='nodesass' %}
     <link rel="stylesheet" href="{{ asset_url }}" />
 {% endstylesheets %}
+```
+
+**Generating source maps**
+
+The filter is able to generate source map files along with the generated assets. Source maps help you locate the origin of CSS rules is the SCSS files while debugging.
+
+In order to generate the source maps, you'll need to specify a public accessible directory where the `.map` files can be placed (`source_map_location`) together with the base path (`source_map_public_dir`) which will be used when generating the urls to the mapping files:
+
+```yml
+nodesass:
+    # ...
+    source_map_location: '%kernel.root_dir%/../web/assets/maps'
+    source_map_public_dir: '/assets/maps'
 ```
 
 ## Recipies

--- a/Resources/filter/nodesass.xml
+++ b/Resources/filter/nodesass.xml
@@ -12,6 +12,8 @@
         <parameter key="assetic.filter.nodesass.output_style">null</parameter>
         <parameter key="assetic.filter.nodesass.precision">null</parameter>
         <parameter key="assetic.filter.nodesass.source_comments">null</parameter>
+        <parameter key="assetic.filter.nodesass.source_map_location">null</parameter>
+        <parameter key="assetic.filter.nodesass.source_map_public_dir">null</parameter>
     </parameters>
 
     <services>
@@ -38,6 +40,12 @@
             </call>
             <call method="setSourceComments">
                 <argument>%assetic.filter.nodesass.source_comments%</argument>
+            </call>
+            <call method="setSourceMapLocation">
+                <argument>%assetic.filter.nodesass.source_map_location%</argument>
+            </call>
+            <call method="setSourceMapPublicDir">
+                <argument>%assetic.filter.nodesass.source_map_public_dir%</argument>
             </call>
         </service>
     </services>


### PR DESCRIPTION
This PR fixes #1 and can be used as follows:

````
assetic:
    filters:
        nodesass:
            bin: '%kernel.project_dir%/node_modules/node-sass/bin/node-sass'
            resource: '%kernel.project_dir%/vendor/gremo/assetic-extra/Resources/filter/nodesass.xml'
            style: compressed
            source_map_location: '%kernel.project_dir%/public/maps'
            source_map_public_dir: '/maps/'
            apply_to: '\.scss$'
````

source_map_location is the location where the source maps are saved. source_map_public_dir is the public web directory that points to the same location.